### PR TITLE
Reconfiguracion Default modulo EC2 y Security Groups

### DIFF
--- a/modules/3-security-groups/main.tf
+++ b/modules/3-security-groups/main.tf
@@ -1,6 +1,6 @@
 # Crear un grupo de seguridad
 resource "aws_security_group" "free_tier_sg" {
-  vpc_id      = aws_vpc.free_tier_vpc.id
+  vpc_id      = var.vpc_id
   description = "Example security group for SSH and HTTP access"
 
   # Permitir tráfico SSH desde una dirección IP específica y desde el servicio de Conexión de instancias de EC2

--- a/modules/3-security-groups/variables.tf
+++ b/modules/3-security-groups/variables.tf
@@ -1,35 +1,42 @@
+variable "vpc_id" {
+  description = "ID of the VPC"
+  type        = string
+}
+
 variable "ssh_port" {
-  description = "Port for SSH"
+  description = "Port for SSH access"
   type        = number
-  default     = 22
 }
 
 variable "http_port" {
-  description = "Port for HTTP"
+  description = "Port for HTTP access"
   type        = number
-  default     = 80
 }
 
 variable "https_port" {
-  description = "Port for HTTPS"
+  description = "Port for HTTPS access"
   type        = number
-  default     = 443
 }
 
 # Variable para la dirección IP permitida para acceder por SSH a la instancia EC2
 variable "ssh_ip" {
-  description = "IP address allowed to SSH into the EC2 instance"  # Descripción de la variable
-  default     = "192.168.0.11/32"                                  # Valor por defecto para la dirección IP permitida
+  description = "IP address allowed to SSH into the EC2 instance"
+  type        = string
 }
 
 # Variable para el rango de direcciones IP del servicio Conexión de instancias de EC2
 variable "ec2_connect_ips" {
-  description = "IP range for EC2 Instance Connect service"  # Descripción de la variable
-  default     = "18.206.107.24/29"                           # Valor por defecto para el rango de direcciones IP
+  description = "IP range for EC2 Instance Connect service"
+  type        = string
 }
 
 # Variable para el CIDR block que permite todo el tráfico
 variable "all_traffic_cidr" {
-  description = "CIDR block to allow all traffic"  # Descripción de la variable
-  default     = "0.0.0.0/0"                        # Valor por defecto para permitir todo el tráfico
+  description = "CIDR block to allow all traffic"
+  type        = string
+}
+
+variable "name" {
+  description = "Name of the Security Group"
+  type        = string
 }

--- a/modules/4-ec2_instance/main.tf
+++ b/modules/4-ec2_instance/main.tf
@@ -2,11 +2,11 @@
 resource "aws_instance" "free_tier_instance" {
   ami                         = var.ami_id
   instance_type               = var.instance_type
-  subnet_id                   = aws_subnet.free_tier_subnet.id
+  subnet_id                   = var.subnet_id
+  vpc_security_group_ids      = [var.security_group_id]
   associate_public_ip_address = true  # Asignar una dirección IPv4 pública a la instancia
-  vpc_security_group_ids      = [aws_security_group.free_tier_sg.id]
 
   tags = {
-    Name = "free-tier-instance"
+    Name = var.name
   }
 }

--- a/modules/4-ec2_instance/variables.tf
+++ b/modules/4-ec2_instance/variables.tf
@@ -1,13 +1,13 @@
 # Variable para el ID de la AMI (Amazon Machine Image) de la instancia EC2
 variable "ami_id" {
   description = "AMI ID for the EC2 instance"       # Descripción de la variable
-  default     = "ami-0c0b74d29acd0cd97"             # Valor por defecto para el ID de la AMI
+  type        = string
 }
 
 # Variable para el tipo de instancia EC2
 variable "instance_type" {
   description = "EC2 instance type"                 # Descripción de la variable
-  default     = "t2.micro"                          # Valor por defecto para el tipo de instancia
+  type        = string
 }
 
 variable "subnet_id" {


### PR DESCRIPTION
[Quitar el Default en las variables de Security Groups]

[usar la variable id en el modulo Security Groups]

[Quitar el Default en las variables del EC2]

[usar la variable name, id_subnet y del Security Groups en el recurso Ec2]